### PR TITLE
Include FacadeServer-frontend files into Omega distro 

### DIFF
--- a/distros/distros.gradle
+++ b/distros/distros.gradle
@@ -92,6 +92,11 @@ task distroPC (type: Zip) {
             }
         }
         into ""
+	
+	//Copy the frontend files (the zip should be put in distros/omega by Jenkins)
+	from(zipTree('FacadeServer-frontend.zip')) {
+	    into "FacadeServer-frontend"
+	}
     }
     //TODO: May need to be hardened against duplicates if transitive modules/libs are later supported (or more added to base)
 }


### PR DESCRIPTION
Quickly put together via GitHub web UI since it's just 3 lines of code - does it look reasonable?

I already added a build step in the build job for Omega in Jenkins which copies the `FacadeServer-frontend.zip` artifact from the build job for FacadeServer-frontend, so if this is merged the Omega zip should include a `FacadeServer-frontend` directory with the frontend files. Opening index.html with a browser, or serving the directory with any webserver (it's just static content) should be enough to make the frontend work.