### PR TITLE
feat: Add build artifact pruning

### DIFF
--- a/distros/Jenkinsfile
+++ b/distros/Jenkinsfile
@@ -1,3 +1,18 @@
+// Minor housekeeping logic
+boolean specialBranch = env.BRANCH_NAME.equals("master") || env.BRANCH_NAME.equals("develop")
+
+// String to use in a property that determines artifact pruning (has to be a String not a number)
+String artifactBuildsToKeep = "2"
+if (specialBranch) {
+    artifactBuildsToKeep = "20"
+}
+
+properties([
+    // Flag for Jenkins to discard attached artifacts after x builds
+    buildDiscarder(logRotator(artifactNumToKeepStr: artifactBuildsToKeep))
+])
+
+// Main pipeline definition
 node ("light-java") {
     stage('Prepare') {
         echo "Going to check out the things !"


### PR DESCRIPTION
Before we accidentally run out of space this time. Although I dunno if 20 each for `master` and `develop` might still be a bit much (about 3 GB each). Something we can clean up further when we have a line of releases on GitHub that the launcher can grab.