### PR TITLE
Fix minor Gradle 8 upgrade issue

### DIFF
--- a/distros/distros.gradle
+++ b/distros/distros.gradle
@@ -17,17 +17,20 @@ repositories {
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
     maven {
         url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        allowInsecureProtocol true // 😱
     }
-    
+
     // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
     // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
     maven {
         url "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
+        allowInsecureProtocol true // 😱
     }
-    
+
     // Snowplow repository for the snowplow dependency of the server facade
     maven {
-	url "http://maven.snplow.com/releases"
+	     url "http://maven.snplow.com/releases"
+       allowInsecureProtocol true // 😱
     }
 }
 
@@ -68,7 +71,7 @@ dependencies {
 task distroPC (type: Zip) {
     description = "Adds modules and facades to a PC distribution of the game. Exact modules and facades are declared in a distro dir like iota"
 
-    archiveName = zipFileName
+    archiveFileName = zipFileName
     duplicatesStrategy = 'exclude'
 
     // We base this distro on the PC version, copied in by Jenkins


### PR DESCRIPTION
PR for reference only, merging immediately to test, then soon enough will swap to the new and actually https secure Artifactory

Originally was triggered by https://github.com/MovingBlocks/Terasology/pull/5109 doing the Gradle upgrade there, since the Gradle version for this repo is linked to that one, at least for the moment.